### PR TITLE
feat: support usage of GET method for API calls

### DIFF
--- a/app.go
+++ b/app.go
@@ -34,6 +34,10 @@ type App struct {
 
 	// By default, the library uses the POST method for all facebook API calls and passes in a method
 	// parameter indicating what the actual verb of the call ought to be. This fails under certain
+	// circumstances with an error of the form "(#3) Application does not have the capability to make this API call".
+	// This option provides the ability to use the GET method to make facebook API calls that require the GET method.
+	// This seems to resolve the issue. Use it only if you encounter the above mentioned issue. Otherwise the default
+	// works fine.
 	UseGetMethodForGetRequests bool
 }
 

--- a/app.go
+++ b/app.go
@@ -31,6 +31,10 @@ type App struct {
 	// Enable appsecret proof in every API call to facebook.
 	// Facebook document: https://developers.facebook.com/docs/graph-api/securing-requests
 	EnableAppsecretProof bool
+
+	// By default, the library uses the POST method for all facebook API calls and passes in a method
+	// parameter indicating what the actual verb of the call ought to be. This fails under certain
+	UseGetMethodForGetRequests bool
 }
 
 // New creates a new App and sets app id and secret.
@@ -232,9 +236,10 @@ func (app *App) GetCode(accessToken string) (code string, err error) {
 // Session creates a session based on current App setting.
 func (app *App) Session(accessToken string) *Session {
 	return &Session{
-		accessToken:          accessToken,
-		app:                  app,
-		enableAppsecretProof: app.EnableAppsecretProof,
+		accessToken:                accessToken,
+		app:                        app,
+		enableAppsecretProof:       app.EnableAppsecretProof,
+		useGetMethodForGetRequests: app.UseGetMethodForGetRequests,
 	}
 }
 

--- a/session.go
+++ b/session.go
@@ -340,11 +340,6 @@ func (session *Session) graph(path string, method Method, params Params) (res Re
 	// always format as json.
 	params["format"] = "json"
 
-	// overwrite method if we are going to use the post method
-	if !session.useGetMethodForGetRequests {
-		params["method"] = method
-	}
-
 	if RFC3339Timestamps || session.RFC3339Timestamps {
 		params["date_format"] = `Y-m-d\TH:i:sP`
 	}
@@ -361,6 +356,8 @@ func (session *Session) graph(path string, method Method, params Params) (res Re
 	if session.useGetMethodForGetRequests && method == GET {
 		response, err = session.sendGetRequest(graphURL, params, &res)
 	} else {
+		// overwrite method since we are going to use the post method
+		params["method"] = method
 		response, err = session.sendPostRequest(graphURL, params, &res)
 	}
 

--- a/session.go
+++ b/session.go
@@ -405,20 +405,13 @@ func (session *Session) prepareParams(params Params) {
 func (session *Session) sendGetRequest(uri string, params Params, res interface{}) (*http.Response, error) {
 	session.prepareParams(params)
 
-	buf := &bytes.Buffer{}
-	_, err := params.Encode(buf)
+	uriWithParams, err := composeURI(uri, params)
 
 	if err != nil {
-		return nil, fmt.Errorf("cannot encode POST params. %v", err)
+		return nil, err
 	}
 
-	if strings.Contains(uri, "?") {
-		uri = fmt.Sprintf("%s&%s", uri, buf.String())
-	} else {
-		uri = fmt.Sprintf("%s?%s", uri, buf.String())
-	}
-
-	request, err := http.NewRequest("GET", uri, nil)
+	request, err := http.NewRequest("GET", uriWithParams, nil)
 
 	if err != nil {
 		return nil, err
@@ -637,3 +630,19 @@ func (session *Session) WithContext(ctx context.Context) *Session {
 	s.context = ctx
 	return &s
 }
+
+func composeURI(uri string, params Params) (string, error) {
+	buf := &bytes.Buffer{}
+	_, err := params.Encode(buf)
+
+	if err != nil {
+		return "", fmt.Errorf("cannot encode POST params. %v", err)
+	}
+
+	if strings.Contains(uri, "?") {
+		return fmt.Sprintf("%s&%s", uri, buf.String()), nil
+	} else {
+		return fmt.Sprintf("%s?%s", uri, buf.String()), nil
+	}
+}
+

--- a/session_test.go
+++ b/session_test.go
@@ -366,3 +366,31 @@ func TestSessionWithCustomBaseUrl(t *testing.T) {
 		t.Fatal("no call to mock server")
 	}
 }
+
+func TestComposeURI(t *testing.T) {
+	params := Params{"fields": "a,b,c"}
+	baseURI := "https://www.testthis.com/path"
+	expected := "https://www.testthis.com/path?fields=a%2Cb%2Cc"
+	uri, err := composeURI(baseURI, params)
+
+	if err != nil {
+		t.Errorf("Unexpected error when composing URI [%s]", err)
+	}
+
+	if uri != expected {
+		t.Errorf("composeURI did not compose the uri as expected. Expected: [%s], Actual: [%s]", expected, uri)
+	}
+
+	// Now test case where baseURI already has a query parameter
+	baseURI = "https://www.testthis.com/path?param1=p1"
+	expected = "https://www.testthis.com/path?param1=p1&fields=a%2Cb%2Cc"
+	uri, err = composeURI(baseURI, params)
+
+	if err != nil {
+		t.Errorf("Unexpected error when composing URI [%s]", err)
+	}
+
+	if uri != expected {
+		t.Errorf("composeURI did not compose the uri as expected. Expected: [%s], Actual: [%s]", expected, uri)
+	}
+}


### PR DESCRIPTION
Currently all facebook API calls are made using the HTTP POST method.
A parameter called "method" is passed in the request body indicating
the actual verb that the API call requires.
Under certain circumstances, facebook returns an error indicating that
the application does not have the capability to make this API call.
This error does not occur when using the GET method to execute these
API calls.